### PR TITLE
'undefined' is not a function (evaluating 'Number.isNaN(b)') fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@
 
 import React from 'react-native'
 
+//Polyfill for Number.isNaN on Safari
+//see https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
+Number.isNaN = Number.isNaN || function(value) {
+    return typeof value === "number" && isNaN(value);
+}
+
 function isPresent (datum) {
   return datum !== undefined && ! Number.isNaN(datum)
 }


### PR DESCRIPTION
'Number.isNaN() is ECMAScript 6 feature, Safari not support this,when running on iOS device,above error will report.
see https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
