### PR TITLE
fixes rn deprecation warning with refactor

### DIFF
--- a/PagedScrollView.js
+++ b/PagedScrollView.js
@@ -149,21 +149,20 @@ var AddPaging = (ComposedComponent, scrollViewRefPropName) => {
     }
 
     scrollToPage (horizontalPage, verticalPage) {
+      this._scrollToPage (horizontalPage, verticalPage, true);
+    }
+
+    scrollWithoutAnimationToPage (horizontalPage, verticalPage) {
+      this._scrollToPage (horizontalPage, verticalPage, false);
+    }
+
+    _scrollToPage (horizontalPage, verticalPage, animated) {
       if (this._scrollView) {
         this._scrollView.scrollTo({
           x: (Math.min(this.state.totalHorizontalPages, Math.max(1, horizontalPage)) - 1) * this.scrollViewWidth,
           y: (Math.min(this.state.totalVerticalPages, Math.max(1, verticalPage)) - 1) * this.scrollViewHeight,
-          animated: true
+          animated: animated
         });
-      }
-    }
-
-    scrollWithoutAnimationToPage (horizontalPage, verticalPage) {
-      if (this._scrollView) {
-        this._scrollView.scrollWithoutAnimationTo(
-          (Math.min(this.state.totalVerticalPages, Math.max(1, verticalPage)) - 1) * this.scrollViewHeight,
-          (Math.min(this.state.totalHorizontalPages, Math.max(1, horizontalPage)) - 1) * this.scrollViewWidth
-        );
       }
     }
 


### PR DESCRIPTION
React Native [has deprecated](https://facebook.github.io/react-native/docs/scrollview.html#scrollwithoutanimationto) `scrollWithoutAnimationTo`

![image](https://cloud.githubusercontent.com/assets/420959/15315162/d089b248-1bca-11e6-8a74-ae6867ce6157.png)
